### PR TITLE
Improve DataLoad AV fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Ensure you have the following dependencies installed. Versions have been updated
 - **PyTorch**: `>=2.0.0`
 - **pandas_datareader**: `>=0.10.0`
 - **alpha_vantage**: `>=2.3.0`
+- **yfinance**: `>=0.2.0`
 
 ## Installation
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -41,9 +41,9 @@ n_obs = 104
 # Number of assets
 n_y = 20
 
-# AlphaVantage API Key.
-# Note: User API keys can be obtained for free from www.alphavantage.co. Users will need a free
-# academic or paid license to download adjusted closing pricing data from AlphaVantage.
+# AlphaVantage API Key (optional).
+# Providing a key downloads prices from AlphaVantage; if left ``None`` the code
+# falls back to ``yfinance`` which does not require registration.
 AV_key = None
 
 # Historical data: Download data (or load cached data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ cvxpylayers>=0.1.7
 torch>=2.0
 pandas_datareader>=0.10
 alpha_vantage>=2.3
+yfinance>=0.2
 psutil>=5.9
 statsmodels>=0.14

--- a/tests/test_data_av_fallback.py
+++ b/tests/test_data_av_fallback.py
@@ -1,0 +1,44 @@
+import pandas as pd
+import numpy as np
+from datetime import datetime
+import pytest
+
+from e2edro import DataLoad
+
+
+def test_av_fallback_uses_yfinance(monkeypatch):
+    tickers = ["AAPL", "MSFT"]
+    dates = pd.date_range("1999-12-30", periods=6, freq="D")
+    multi_idx = pd.MultiIndex.from_product([["Adj Close"], tickers])
+    fake_prices = pd.DataFrame(
+        np.arange(len(dates) * len(tickers)).reshape(len(dates), len(tickers)),
+        index=dates,
+        columns=multi_idx,
+    )
+
+    def fake_download(*args, **kwargs):
+        return fake_prices
+
+    def fake_ff(name, start=None, end=None):
+        ff_dates = pd.date_range(start, end, freq="D")
+        cols = ["Mkt-RF", "SMB", "HML", "RMW", "CMA", "RF"]
+        data = pd.DataFrame(np.random.rand(len(ff_dates), len(cols)), index=ff_dates, columns=cols)
+        return {0: data}
+
+    # Patch network calls
+    monkeypatch.setattr(DataLoad.yf, "download", fake_download)
+    monkeypatch.setattr(DataLoad.pdr, "get_data_famafrench", fake_ff)
+    monkeypatch.setattr(DataLoad, "TimeSeries", lambda *a, **k: pytest.fail("TimeSeries should not be called"))
+
+    X, Y = DataLoad.AV(
+        "2000-01-01",
+        "2000-01-04",
+        [0.6, 0.4],
+        n_obs=2,
+        n_y=2,
+        use_cache=False,
+        AV_key=None,
+    )
+
+    assert Y.data.shape[1] == 2
+    assert not Y.data.empty


### PR DESCRIPTION
## Summary
- use `yfinance` when no AlphaVantage key is provided
- update docs and example comments
- document `yfinance` dependency
- add regression test for the `yfinance` fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*