### PR TITLE
Fix example import path

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -7,6 +7,14 @@ import pickle
 import torch
 import pandas as pd
 import matplotlib.pyplot as plt
+import os
+import sys
+
+# Ensure the package is importable when running this script directly
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 from e2edro import PlotFunctions as pf
 from e2edro import BaseModels as bm
 from e2edro import DataLoad as dl


### PR DESCRIPTION
## Summary
- ensure `examples/main.py` can import package when executed directly

## Testing
- `pytest -q` *(fails: pandas/torch not installed)*