### PR TITLE
Remove alpha_vantage dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ Ensure you have the following dependencies installed. Versions have been updated
 - **cvxpylayers**: `>=0.1.7`
 - **PyTorch**: `>=2.0.0`
 - **pandas_datareader**: `>=0.10.0`
-- **alpha_vantage**: `>=2.3.0`
 - **yfinance**: `>=0.2.0`
 
 ## Installation

--- a/e2edro/DataLoad.py
+++ b/e2edro/DataLoad.py
@@ -8,9 +8,7 @@ import torch.nn as nn
 import pandas as pd
 import pandas_datareader as pdr
 import numpy as np
-from alpha_vantage.timeseries import TimeSeries
 import yfinance as yf
-import time
 import statsmodels.api as sm
 
 
@@ -332,9 +330,9 @@ def synthetic_exp(
 
 
 ####################################################################################################
-# Option 4: Factors from Kenneth French's data library and asset data from AlphaVantage
+# Option 4: Factors from Kenneth French's data library and asset data from Yahoo Finance
 # https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html
-# https://www.alphavantage.co
+# https://finance.yahoo.com
 ####################################################################################################
 def AV(
     start: str,
@@ -347,7 +345,7 @@ def AV(
     save_results: bool = False,
     AV_key: str = None,
 ):
-    """Load data from Kenneth French's data library and from AlphaVantage
+    """Load data from Kenneth French's data library and from Yahoo Finance
     https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html
     https://www.alphavantage.co
 
@@ -370,9 +368,8 @@ def AV(
     save_results : bool, optional
         State whether the data should be cached for future use. . The default is False.
     AV_key : str, optional
-        AlphaVantage user key to access their API. Keys are free for academic users. The default
-        is None. When ``None``, asset prices are downloaded using ``yfinance`` instead of
-        ``alpha_vantage``.
+        Unused parameter kept for backwards compatibility. Asset prices are
+        always downloaded using ``yfinance``.
 
     Returns
     -------
@@ -412,26 +409,13 @@ def AV(
         if n_y is not None:
             tick_list = tick_list[:n_y]
 
-        if AV_key is None:
-            # Use publicly available data via yfinance when no API key is provided
-            Y = yf.download(
-                tick_list,
-                start="1999-01-01",
-                end=end,
-                progress=False,
-            )["Adj Close"]
-        else:
-            ts = TimeSeries(key=AV_key, output_format="pandas", indexing_type="date")
-
-            # Download asset data from AlphaVantage
-            Y = []
-            for tick in tick_list:
-                data, _ = ts.get_daily_adjusted(symbol=tick, outputsize="full")
-                data = data["5. adjusted close"]
-                Y.append(data)
-                time.sleep(12.5)
-            Y = pd.concat(Y, axis=1)
-            Y = Y[::-1]
+        # Download asset data using yfinance
+        Y = yf.download(
+            tick_list,
+            start="1999-01-01",
+            end=end,
+            progress=False,
+        )["Adj Close"]
 
         Y = Y["1999-1-1":end].pct_change()
         Y = Y[start:end]

--- a/examples/main.py
+++ b/examples/main.py
@@ -49,9 +49,8 @@ n_obs = 104
 # Number of assets
 n_y = 20
 
-# AlphaVantage API Key (optional).
-# Providing a key downloads prices from AlphaVantage; if left ``None`` the code
-# falls back to ``yfinance`` which does not require registration.
+# API key placeholder (not used).
+# Asset prices are always downloaded via ``yfinance``.
 AV_key = None
 
 # Historical data: Download data (or load cached data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ cvxpy>=1.3
 cvxpylayers>=0.1.7
 torch>=2.0
 pandas_datareader>=0.10
-alpha_vantage>=2.3
 yfinance>=0.2
 psutil>=5.9
 statsmodels>=0.14

--- a/tests/test_data_av_fallback.py
+++ b/tests/test_data_av_fallback.py
@@ -16,7 +16,10 @@ def test_av_fallback_uses_yfinance(monkeypatch):
         columns=multi_idx,
     )
 
+    called = {"flag": False}
+
     def fake_download(*args, **kwargs):
+        called["flag"] = True
         return fake_prices
 
     def fake_ff(name, start=None, end=None):
@@ -28,7 +31,6 @@ def test_av_fallback_uses_yfinance(monkeypatch):
     # Patch network calls
     monkeypatch.setattr(DataLoad.yf, "download", fake_download)
     monkeypatch.setattr(DataLoad.pdr, "get_data_famafrench", fake_ff)
-    monkeypatch.setattr(DataLoad, "TimeSeries", lambda *a, **k: pytest.fail("TimeSeries should not be called"))
 
     X, Y = DataLoad.AV(
         "2000-01-01",
@@ -42,3 +44,4 @@ def test_av_fallback_uses_yfinance(monkeypatch):
 
     assert Y.data.shape[1] == 2
     assert not Y.data.empty
+    assert called["flag"]


### PR DESCRIPTION
## Summary
- switch all price downloads to `yfinance`
- drop `alpha_vantage` from dependencies
- update documentation and example comments
- adjust test to reflect new behaviour

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*