### PR TITLE
Allow running equal_weight without diffcp

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Ensure you have the following dependencies installed. Versions have been updated
 - **Matplotlib**: `>=3.6.0`
 - **cvxpy**: `>=1.3.0`
 - **cvxpylayers**: `>=0.1.7`
-- **diffcp**: `>=1.0.15`
+- **diffcp**: `>=1.0.15` *(required only for models that use the differentiable optimization layers)*
 - **PyTorch**: `>=2.0.0`
 - **pandas_datareader**: `>=0.10.0`
 - **yfinance**: `>=0.2.0`

--- a/e2edro/BaseModels.py
+++ b/e2edro/BaseModels.py
@@ -10,7 +10,14 @@ from torch.utils.data import DataLoader
 
 from . import RiskFunctions as rf
 from . import PortfolioClasses as pc
-from . import e2edro as e2e
+
+# ``e2edro`` pulls in ``cvxpylayers`` which depends on the optional
+# ``diffcp`` package. Importing it unconditionally prevents using the
+# simpler models (e.g. ``equal_weight``) on systems where ``diffcp`` is
+# not installed.  To allow these models to run without the optional
+# dependency we defer importing ``e2edro`` until it is actually needed
+# (in ``pred_then_opt``).
+
 
 
 ####################################################################################################
@@ -74,6 +81,11 @@ class pred_then_opt(nn.Module):
         self.pred_layer.bias.requires_grad = False
 
         # LAYER: Optimization
+        # ``e2edro`` (and by extension ``cvxpylayers``) is only required when
+        # constructing the optimization layer. Import here to avoid importing it
+        # when using simpler models that do not rely on these packages.
+        from . import e2edro as e2e
+
         self.opt_layer = e2e.OPT_LAYER_MAP[opt_layer](n_y, n_obs, e2e.RISK_FUNC_MAP[prisk])
         # self.opt_layer = e2e.nominal(n_y, n_obs, eval('rf.'+prisk))
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -18,7 +18,6 @@ if PROJECT_ROOT not in sys.path:
 from e2edro import PlotFunctions as pf
 from e2edro import BaseModels as bm
 from e2edro import DataLoad as dl
-from e2edro import e2edro as e2e
 
 
 plt.close("all")
@@ -162,6 +161,10 @@ if use_cache:
     with open(cache_path + "dr_net_tv_learn_theta.pkl", "rb") as inp:
         dr_net_tv_learn_theta = pickle.load(inp)
 else:
+    # Import here to avoid importing heavy dependencies when using only the
+    # equal-weight example. ``e2edro`` requires ``cvxpylayers`` and ``diffcp``.
+    from e2edro import e2edro as e2e
+
     # Exp 1: Equal weight portfolio
     ew_net = bm.equal_weight(n_x, n_y, n_obs)
     ew_net.net_roll_test(X, Y, n_roll=4)
@@ -784,6 +787,9 @@ if use_cache:
     with open(cache_path_exp5 + "dr_net_3layer.pkl", "rb") as inp:
         dr_net_3layer = pickle.load(inp)
 else:
+
+    # Import heavy dependencies only when running the synthetic examples that rely on the differentiable optimization layers.
+    from e2edro import e2edro as e2e
 
     # ***********************************************************************************************
     # Linear models


### PR DESCRIPTION
## Summary
- avoid importing `e2edro` in `BaseModels` unless the optimization layer is created
- lazily import heavy deps inside `examples/main.py`
- document that `diffcp` is only needed for models using differentiable layers

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for pandas and e2edro)*