### PR TITLE
Improve backtest length validation

### DIFF
--- a/e2edro/BaseModels.py
+++ b/e2edro/BaseModels.py
@@ -149,9 +149,8 @@ class pred_then_opt(nn.Module):
         """
 
         # Declare backtest object to hold the test results
-        portfolio = pc.backtest(
-            len(Y.test()) - Y.n_obs, self.n_y, Y.test().index[Y.n_obs :]
-        )
+        len_test = len(Y.test()) - Y.n_obs
+        portfolio = pc.backtest(len_test, self.n_y, Y.test().index[Y.n_obs :])
 
         # Store initial train/test split
         init_split = Y.split
@@ -246,9 +245,8 @@ class equal_weight:
         """
 
         # Declare backtest object to hold the test results
-        portfolio = pc.backtest(
-            len(Y.test()) - Y.n_obs, self.n_y, Y.test().index[Y.n_obs :]
-        )
+        len_test = len(Y.test()) - Y.n_obs
+        portfolio = pc.backtest(len_test, self.n_y, Y.test().index[Y.n_obs :])
 
         test_set = DataLoader(pc.SlidingWindow(X.test(), Y.test(), self.n_obs, 0))
 

--- a/e2edro/PortfolioClasses.py
+++ b/e2edro/PortfolioClasses.py
@@ -73,6 +73,12 @@ class backtest:
         vol: Volatility (i.e., standard deviation of the returns) (dim: scalar)
         sharpe: pseudo-Sharpe ratio defined as 'mean / vol' (dim: scalar)
         """
+        if len_test <= 0:
+            raise ValueError(
+                "len_test must be positive; check that the test split contains "
+                "more than 'n_obs' samples"
+            )
+
         self.weights = np.zeros((len_test, n_y))
         self.rets = np.zeros(len_test)
         self.dates = dates[-len_test:]

--- a/e2edro/e2edro.py
+++ b/e2edro/e2edro.py
@@ -471,9 +471,8 @@ class e2e_net(nn.Module):
         """
 
         # Declare backtest object to hold the test results
-        portfolio = pc.backtest(
-            len(Y.test()) - Y.n_obs, self.n_y, Y.test().index[Y.n_obs :]
-        )
+        len_test = len(Y.test()) - Y.n_obs
+        portfolio = pc.backtest(len_test, self.n_y, Y.test().index[Y.n_obs :])
 
         # Store trained gamma and delta values
         if self.model_type == "nom":


### PR DESCRIPTION
## Summary
- validate that the backtest length is positive
- compute `len_test` explicitly before creating backtest objects

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*