### PR TITLE
Fix experiment cache directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ installing the dependencies you can execute it with:
 python examples/main.py
 ```
 
-The script caches downloaded data and intermediate results in the `cache/`
-directory. If the folder does not already exist it will be created
-automatically when running the loader.
+The script caches downloaded data and intermediate results in the
+`cache/exp/` directory (and `cache/exp5/` for the synthetic-data example).
+These folders are created automatically when running the loader so no manual
+setup is required.
 
 ## Testing
 

--- a/examples/main.py
+++ b/examples/main.py
@@ -29,6 +29,9 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 
 # Path to cache the data, models and results
 cache_path = "./cache/exp/"
+# Ensure the cache directories exist so saving results does not fail
+os.makedirs(cache_path, exist_ok=True)
+os.makedirs(os.path.join(cache_path, "plots"), exist_ok=True)
 
 ####################################################################################################
 # Experiments 1-4 (with hisotrical data): Load data
@@ -724,6 +727,9 @@ validation_table.set_axis(
 
 # Path to cache the data, models and results
 cache_path_exp5 = "./cache/exp5/"
+# Ensure cache directories for experiment 5 also exist
+os.makedirs(cache_path_exp5, exist_ok=True)
+os.makedirs(os.path.join(cache_path_exp5, "plots"), exist_ok=True)
 
 # ---------------------------------------------------------------------------------------------------
 # Experiment 5: Load data


### PR DESCRIPTION
## Summary
- create experiment cache directories on startup
- clarify in README that cache folders are auto-created

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*