### PR TITLE
Fix pickling by using dill

### DIFF
--- a/examples/main.py
+++ b/examples/main.py
@@ -3,7 +3,7 @@
 ####################################################################################################
 # Import libraries
 ####################################################################################################
-import pickle
+import dill as pickle
 import torch
 import pandas as pd
 import matplotlib.pyplot as plt

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ pandas_datareader>=0.10
 yfinance>=0.2
 psutil>=5.9
 statsmodels>=0.14
+dill>=0.3


### PR DESCRIPTION
## Summary
- use `dill` for model serialization to support pickling of nested functions
- add dill as a dependency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*