### PR TITLE
Load hyperparameters from YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ python examples/main.py
 ```
 
 The default `examples/config.yaml` enables all experiments (`exp1`-`exp5`).
-Edit this file to run a subset.
+This file also defines a `hyperparams` section shared across the experiments.
+Edit it to adjust learning rates, loss functions or to run a subset of
+experiments.
 
 The scripts cache downloaded data and intermediate results in the
 `cache/exp/` directory (and `cache/exp5/` for the synthetic-data example).

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,3 +1,13 @@
 experiments:
   - exp1
 
+# Common hyperparameters used by the experiments.
+hyperparams:
+  perf_loss: sharpe_loss
+  perf_period: 13
+  pred_loss_factor: 0.5
+  prisk: p_var
+  dr_layer: hellinger
+  lr_list: [0.005]
+  epoch_list: [5]
+

--- a/examples/exp_hist.py
+++ b/examples/exp_hist.py
@@ -9,6 +9,7 @@ import matplotlib.pyplot as plt
 import os
 import sys
 from typing import Iterable
+import yaml
 
 # Ensure the package is importable when running this script directly
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -21,6 +22,15 @@ from e2edro import DataLoad as dl
 
 
 plt.close("all")
+
+# Load hyperparameters from YAML config if available
+_cfg_path = os.environ.get("CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.yaml"))
+if os.path.exists(_cfg_path):
+    with open(_cfg_path, "r") as _f:
+        _cfg = yaml.safe_load(_f) or {}
+    HYP = _cfg.get("hyperparams", {})
+else:
+    HYP = {}
 
 # Determine which experiments to run when executed via run_experiments.py
 _exp_env = os.environ.get("EXP_LIST")
@@ -45,18 +55,18 @@ os.makedirs(os.path.join(cache_path, "plots"), exist_ok=True)
 ####################################################################################################
 
 # Data frequency and start/end dates
-freq = "weekly"
-start = "1998-01-01"
-end = "2025-04-01"
+freq = HYP.get("freq", "weekly")
+start = HYP.get("start", "1998-01-01")
+end = HYP.get("end", "2025-04-01")
 
 # Train, validation and test split percentage
-split = [0.6, 0.4]
+split = HYP.get("split", [0.6, 0.4])
 
 # Number of observations per window
-n_obs = 104
+n_obs = HYP.get("n_obs", 104)
 
 # Number of assets
-n_y = 20
+n_y = HYP.get("n_y", 20)
 
 # API key placeholder (not used).
 # Asset prices are always downloaded via ``yfinance``.
@@ -90,29 +100,29 @@ stats = dl.statanalysis(X.data, Y.data)
 # ---------------------------------------------------------------------------------------------------
 
 # Performance loss function and performance period 'v+1'
-perf_loss = "sharpe_loss"
-perf_period = 13
+perf_loss = HYP.get("perf_loss", "sharpe_loss")
+perf_period = HYP.get("perf_period", 13)
 
 # Weight assigned to MSE prediction loss function
-pred_loss_factor = 0.5
+pred_loss_factor = HYP.get("pred_loss_factor", 0.5)
 
 # Risk function (default set to variance)
-prisk = "p_var"
+prisk = HYP.get("prisk", "p_var")
 
 # Robust decision layer to use: hellinger or tv
-dr_layer = "hellinger"
+dr_layer = HYP.get("dr_layer", "hellinger")
 
 # List of learning rates to test
-lr_list = [0.005]
+lr_list = HYP.get("lr_list", [0.005])
 
 # List of total no. of epochs to test
-epoch_list = [5]
+epoch_list = HYP.get("epoch_list", [5])
 
 # For replicability, set the random seed for the numerical experiments
-set_seed = 1000
+set_seed = HYP.get("set_seed", 1000)
 
 # Load saved models (default is False)
-use_cache = False
+use_cache = HYP.get("use_cache", False)
 
 # ---------------------------------------------------------------------------------------------------
 # Run

--- a/examples/exp_synthetic.py
+++ b/examples/exp_synthetic.py
@@ -4,6 +4,7 @@ import matplotlib.pyplot as plt
 import os
 import sys
 from typing import Iterable
+import yaml
 
 # Ensure the package is importable when running this script directly
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -24,18 +25,29 @@ cache_path_exp5 = "./cache/exp5/"
 os.makedirs(cache_path_exp5, exist_ok=True)
 os.makedirs(os.path.join(cache_path_exp5, "plots"), exist_ok=True)
 
+# Load hyperparameters from YAML config if available
+_cfg_path = os.environ.get("CONFIG_PATH", os.path.join(os.path.dirname(__file__), "config.yaml"))
+if os.path.exists(_cfg_path):
+    with open(_cfg_path, "r") as _f:
+        _cfg = yaml.safe_load(_f) or {}
+    HYP = _cfg.get("hyperparams", {})
+else:
+    HYP = {}
+
 # ---------------------------------------------------------------------------------------------------
 # Experiment 5: Load data
 # ---------------------------------------------------------------------------------------------------
 
 # Train, validation and test split percentage
-split = [0.7, 0.3]
+split = HYP.get("split", [0.7, 0.3])
 
-# Number of feattures and assets
-n_x, n_y = 5, 10
+# Number of features and assets
+n_x = HYP.get("n_x", 5)
+n_y = HYP.get("n_y", 10)
 
 # Number of observations per window and total number of observations
-n_obs, n_tot = 100, 1200
+n_obs = HYP.get("n_obs", 100)
+n_tot = HYP.get("n_tot", 1200)
 
 # Synthetic data: randomly generate data from a linear model
 X, Y = dl.synthetic_exp(n_x=n_x, n_y=n_y, n_obs=n_obs, n_tot=n_tot, split=split)
@@ -45,29 +57,29 @@ X, Y = dl.synthetic_exp(n_x=n_x, n_y=n_y, n_obs=n_obs, n_tot=n_tot, split=split)
 # ---------------------------------------------------------------------------------------------------
 
 # Performance loss function and performance period 'v+1'
-perf_loss = "sharpe_loss"
-perf_period = 13
+perf_loss = HYP.get("perf_loss", "sharpe_loss")
+perf_period = HYP.get("perf_period", 13)
 
 # Weight assigned to MSE prediction loss function
-pred_loss_factor = 0.5
+pred_loss_factor = HYP.get("pred_loss_factor", 0.5)
 
 # Risk function (default set to variance)
-prisk = "p_var"
+prisk = HYP.get("prisk", "p_var")
 
 # Robust decision layer to use: hellinger or tv
-dr_layer = "hellinger"
+dr_layer = HYP.get("dr_layer", "hellinger")
 
 # Determine whether to train the prediction weights Theta
-train_pred = True
+train_pred = HYP.get("train_pred", True)
 
 # List of learning rates to test
-lr_list = [0.005]
+lr_list = HYP.get("lr_list", [0.005])
 
 # List of total no. of epochs to test
-epoch_list = [5]
+epoch_list = HYP.get("epoch_list", [5])
 
 # Load saved models (default is False)
-use_cache = False
+use_cache = HYP.get("use_cache", False)
 
 # ---------------------------------------------------------------------------------------------------
 # Run

--- a/examples/main.py
+++ b/examples/main.py
@@ -16,6 +16,8 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 def run_from_config(cfg_path: str) -> None:
     with open(cfg_path, "r") as f:
         cfg = yaml.safe_load(f)
+    # Provide the path to sub-scripts so they can load hyperparameters
+    os.environ["CONFIG_PATH"] = cfg_path
     experiments = cfg.get("experiments", [])
     hist_exps = [e for e in experiments if e in {"exp1", "exp2", "exp3", "exp4"}]
     synth = "exp5" in experiments


### PR DESCRIPTION
## Summary
- store common training hyperparameters in `examples/config.yaml`
- pass config path to sub-scripts from `examples/main.py`
- load hyperparameters in `exp_hist.py` and `exp_synthetic.py`
- mention new `hyperparams` section in the README

## Testing
- `python -m py_compile examples/exp_hist.py examples/exp_synthetic.py examples/main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*